### PR TITLE
Add veYFI to readme and cut down verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@ Audit reports (note some reports are kept private upon request from clients):
 
 ### 1. [Audits From Fellowship Block 0 (pilot), x4](https://github.com/yacademy/audits/tree/main/block_000)
 ### 2. [Audits From Fellowship Block 1, x4](https://github.com/yacademy/audits/tree/main/block_001)
-### 3. [Ohm audit by residents: Invader-tak, Nibbler, Jackson and Engn33r](https://github.com/yacademy/audits/tree/main/Olympus_DAO/Tyche_OlympusGive.pdf)
+### 3. [Ohm by residents](https://github.com/yacademy/audits/tree/main/Olympus_DAO/Tyche_OlympusGive.pdf)
+### 4. [Yearn veYFI by residents](https://github.com/yacademy/audits/blob/main/Yearn/yAcademy_veYFI_review.pdf)
 
 Audits underway during April-May-June 2022:
 
-### 4. Morph
-### 5. Manifold
-### 6. JonesDAO
-### 7. Sushi Guard
-### 8. Olympus (recurring)
-
-
-
+|Protocol|
+|--------|
+|Morph|
+|Manifold|
+|JonesDAO|
+|Sushi Guard|
+|Olympus (recurring)|


### PR DESCRIPTION
Rationale:

- cut down verbosity on README for legibility
  - removed "authors" since they are already credited on first page of report
  - table format to avoid re-ordering numbers in future additions

@yacademy @invader-tak please modify protocol upcoming audits when you can.